### PR TITLE
Workaround for debian bug #829680

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -13,3 +13,8 @@
   set_fact: create_authkey=True
   when: corosync_installed|changed
 
+# Workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=829680
+- name: Ensure directory uidgid.d exists for pcs package
+  file:
+    name: /etc/corosync/uidgid.d/
+    state: directory


### PR DESCRIPTION
Some pcs commands complain about the folder missing (e. g. `pcs config backup`).

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=829680